### PR TITLE
Fix build error with latest FlutterEngine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.5.2)
 
 project(flutter_wayland)
 
-set(FLUTTER_ENGINE_SHA b9523318caa1a99ffde8adaf331212eb879cabc9)
+set(FLUTTER_ENGINE_SHA f001ea29f1b9664d928acfddbbd9c76a942e2238)
 
 set(FLUTTER_EMBEDDER_ARTIFACTS_ZIP ${CMAKE_BINARY_DIR}/flutter_embedder_${FLUTTER_ENGINE_SHA}.zip)
 set(FLUTTER_ARTIFACTS_ZIP          ${CMAKE_BINARY_DIR}/flutter_artifact_${FLUTTER_ENGINE_SHA}.zip)

--- a/src/flutter_application.cc
+++ b/src/flutter_application.cc
@@ -94,8 +94,8 @@ FlutterApplication::FlutterApplication(
   FlutterProjectArgs args = {
       .struct_size = sizeof(FlutterProjectArgs),
       .assets_path = bundle_path.c_str(),
-      .main_path__unused__ = "",
-      .packages_path__unused__ = "",
+      .main_path__unused__ = nullptr,
+      .packages_path__unused__ = nullptr,
       .icu_data_path = icu_data_path.c_str(),
       .command_line_argc = static_cast<int>(command_line_args_c.size()),
       .command_line_argv = command_line_args_c.data(),

--- a/src/flutter_application.cc
+++ b/src/flutter_application.cc
@@ -94,8 +94,8 @@ FlutterApplication::FlutterApplication(
   FlutterProjectArgs args = {
       .struct_size = sizeof(FlutterProjectArgs),
       .assets_path = bundle_path.c_str(),
-      .main_path = "",
-      .packages_path = "",
+      .main_path__unused__ = "",
+      .packages_path__unused__ = "",
       .icu_data_path = icu_data_path.c_str(),
       .command_line_argc = static_cast<int>(command_line_args_c.size()),
       .command_line_argv = command_line_args_c.data(),

--- a/src/main.cc
+++ b/src/main.cc
@@ -59,7 +59,7 @@ static bool Main(std::vector<std::string> args) {
   const size_t kHeight = 600;
 
   for (const auto& arg : args) {
-    FLWAY_ERROR << "Arg: " << arg << std::endl;
+    FLWAY_LOG << "Arg: " << arg << std::endl;
   }
 
   WaylandDisplay display(kWidth, kHeight);


### PR DESCRIPTION
When building with the latest FlutterEngine, the following error will occur.  Also, I think that one log output is not the most appropriate level, so I fixed it.

```
$ ninja
[1/2] Building CXX object CMakeFiles/flutter_wayland.dir/src/flutter_application.cc.o
FAILED: CMakeFiles/flutter_wayland.dir/src/flutter_application.cc.o 
/usr/bin/c++   -I/usr/include/libdrm -I.  -MD -MT CMakeFiles/flutter_wayland.dir/src/flutter_application.cc.o -MF CMakeFiles/flutter_wayland.dir/src/flutter_application.cc.o.d -o CMakeFiles/flutter_wayland.dir/src/flutter_application.cc.o -c ../src/flutter_application.cc
../src/flutter_application.cc: In constructor ‘flutter::FlutterApplication::FlutterApplication(std::__cxx11::string, const std::vector<std::__cxx11::basic_string<char> >&, flutter::FlutterApplication::RenderDelegate&)’:
../src/flutter_application.cc:102:3: error: ‘FlutterProjectArgs’ has no non-static data member named ‘main_path’
   };
   ^
ninja: build stopped: subcommand failed.
```
