### PR TITLE
Support Wayland mouse event

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.5.2)
 
 project(flutter_wayland)
 
-set(FLUTTER_ENGINE_SHA b9523318caa1a99ffde8adaf331212eb879cabc9)
+set(FLUTTER_ENGINE_SHA f001ea29f1b9664d928acfddbbd9c76a942e2238)
 
 set(FLUTTER_EMBEDDER_ARTIFACTS_ZIP ${CMAKE_BINARY_DIR}/flutter_embedder_${FLUTTER_ENGINE_SHA}.zip)
 set(FLUTTER_ARTIFACTS_ZIP          ${CMAKE_BINARY_DIR}/flutter_artifact_${FLUTTER_ENGINE_SHA}.zip)

--- a/src/flutter_application.cc
+++ b/src/flutter_application.cc
@@ -94,8 +94,8 @@ FlutterApplication::FlutterApplication(
   FlutterProjectArgs args = {
       .struct_size = sizeof(FlutterProjectArgs),
       .assets_path = bundle_path.c_str(),
-      .main_path__unused__ = "",
-      .packages_path__unused__ = "",
+      .main_path__unused__ = nullptr,
+      .packages_path__unused__ = nullptr,
       .icu_data_path = icu_data_path.c_str(),
       .command_line_argc = static_cast<int>(command_line_args_c.size()),
       .command_line_argv = command_line_args_c.data(),

--- a/src/flutter_application.cc
+++ b/src/flutter_application.cc
@@ -94,8 +94,8 @@ FlutterApplication::FlutterApplication(
   FlutterProjectArgs args = {
       .struct_size = sizeof(FlutterProjectArgs),
       .assets_path = bundle_path.c_str(),
-      .main_path = "",
-      .packages_path = "",
+      .main_path__unused__ = "",
+      .packages_path__unused__ = "",
       .icu_data_path = icu_data_path.c_str(),
       .command_line_argc = static_cast<int>(command_line_args_c.size()),
       .command_line_argv = command_line_args_c.data(),

--- a/src/main.cc
+++ b/src/main.cc
@@ -59,7 +59,7 @@ static bool Main(std::vector<std::string> args) {
   const size_t kHeight = 600;
 
   for (const auto& arg : args) {
-    FLWAY_ERROR << "Arg: " << arg << std::endl;
+    FLWAY_LOG << "Arg: " << arg << std::endl;
   }
 
   WaylandDisplay display(kWidth, kHeight);

--- a/src/wayland_display.cc
+++ b/src/wayland_display.cc
@@ -157,6 +157,11 @@ WaylandDisplay::~WaylandDisplay() {
     shell_ = nullptr;
   }
 
+  if (seat_) {
+    wl_seat_destroy(seat_);
+    seat_ = nullptr;
+  }
+
   if (egl_surface_) {
     eglDestroySurface(egl_display_, egl_surface_);
     egl_surface_ = nullptr;

--- a/src/wayland_display.h
+++ b/src/wayland_display.h
@@ -18,7 +18,20 @@ namespace flutter {
 
 class WaylandDisplay : public FlutterApplication::RenderDelegate {
  public:
-  WaylandDisplay(size_t width, size_t height);
+  class InputDelegate {
+   public:
+    virtual void OnDisplayPointerEnter(uint32_t x, uint32_t y) = 0;
+
+    virtual void OnDisplayPointerLeave() = 0;
+
+    virtual void OnDisplayPointerMotion(uint32_t x, uint32_t y) = 0;
+
+    virtual void OnDisplayPointerButton(uint32_t button, uint32_t status) = 0;
+
+    virtual void OnDisplayPointerAxis(uint32_t axis, uint32_t value) = 0;
+  };
+
+  WaylandDisplay(size_t width, size_t height, InputDelegate& input_delegate);
 
   ~WaylandDisplay();
 
@@ -29,6 +42,10 @@ class WaylandDisplay : public FlutterApplication::RenderDelegate {
  private:
   static const wl_registry_listener kRegistryListener;
   static const wl_shell_surface_listener kShellSurfaceListener;
+  static const wl_seat_listener kSeatListener;
+  static const wl_pointer_listener kPointerListener;
+
+  InputDelegate& input_delegate_;
   bool valid_ = false;
   const int screen_width_;
   const int screen_height_;
@@ -36,6 +53,8 @@ class WaylandDisplay : public FlutterApplication::RenderDelegate {
   wl_registry* registry_ = nullptr;
   wl_compositor* compositor_ = nullptr;
   wl_shell* shell_ = nullptr;
+  wl_seat* seat_ = nullptr;
+  wl_pointer* pointer_ = nullptr;
   wl_shell_surface* shell_surface_ = nullptr;
   wl_surface* surface_ = nullptr;
   wl_egl_window* window_ = nullptr;


### PR DESCRIPTION
Supported Wayland mouse events as they were not connected to Flutter Engine. With this support, we can check button operation and swipe movement etc.